### PR TITLE
flightlog: add schema and related methods

### DIFF
--- a/LogSchema.json
+++ b/LogSchema.json
@@ -1,0 +1,119 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "title": "Flight Log schema for Digital Sky",
+  "description": "This is the flight log schema for digital sky flight logs. One file that follows this schema should be generated for every permission artefact",
+  "required": [
+    "signature",
+    "FlightLog"
+  ],
+  "properties": {
+    "signature": {
+      "$id": "#/properties/signature",
+      "type": "string",
+      "title": "The Signature Schema",
+      "description": "Base64 encoded RSA2048 with SHA256 Signature of the FlightLog element. "
+    },
+    "FlightLog": {
+      "$id": "#/properties/FlightLog",
+      "type": "object",
+      "title": "The Flightlog Schema",
+      "description": "Contains all the flight log related information. ",
+      "required": [
+        "PermissionArtefact",
+        "previous_log_hash",
+        "LogEntries"
+      ],
+      "properties": {
+        "PermissionArtefact": {
+          "$id": "#/properties/FlightLog/properties/PermissionArtefact",
+          "type": "string",
+          "title": "Permission Artefact ID",
+          "description": "The ID of the current permission artefact against which the log is being generated. "
+        },
+        "previous_log_hash": {
+          "$id": "#/properties/FlightLog/properties/previous_log_hash",
+          "type": "string",
+          "title": "The Previous Log hash",
+          "description": "This contains the base64 encoded hash of the most recent flight log that was generated",
+          "default": ""
+        },
+        "LogEntries": {
+          "$id": "#/properties/FlightLog/properties/LogEntries",
+          "type": "array",
+          "title": "The Logentries Schema",
+          "items": {
+            "$id": "#/properties/FlightLog/properties/LogEntries/items",
+            "type": "object",
+            "title": "Flight Log items",
+            "required": [
+              "Entry_type",
+              "TimeStamp",
+              "Longitude",
+              "Latitude",
+              "Altitude"
+            ],
+            "properties": {
+              "Entry_type": {
+                "$id": "#/properties/FlightLog/properties/LogEntries/items/properties/Entry_type",
+                "type": "string",
+                "enum": [
+                  "GEOFENCE_BREACH",
+                  "TAKEOFF/ARM",
+                  "TIME_BREACH",
+                  "LAND/DISARM"
+                ],
+                "title": "Flight Log entries",
+                "description": "Every entry in the flight log should be one of the four types"
+              },
+              "TimeStamp": {
+                "$id": "#/properties/FlightLog/properties/LogEntries/items/properties/TimeStamp",
+                "type": "integer",
+                "title": "Unix timestamp of the recorded entry",
+                "default": 0
+              },
+              "Longitude": {
+                "$id": "#/properties/FlightLog/properties/LogEntries/items/properties/Longitude",
+                "type": "number",
+                "title": "The Longitude in decimal Degrees",
+                "default": 0,
+                "examples": [
+                  12.34567
+                ]
+              },
+              "Latitude": {
+                "$id": "#/properties/FlightLog/properties/LogEntries/items/properties/Latitude",
+                "type": "number",
+                "title": "The Latitude in decimal degrees",
+                "default": 0.0,
+                "examples": [
+                  12.34567
+                ]
+              },
+              "Altitude": {
+                "$id": "#/properties/FlightLog/properties/LogEntries/items/properties/Altitude",
+                "type": "number",
+                "title": "The ellipsoidal height in m",
+                "default": 0,
+                "examples": [
+                  100.1
+                ]
+              },
+              "CRC": {
+                "$id": "#/properties/FlightLog/properties/LogEntries/items/properties/CRC",
+                "type": "integer",
+                "title": "The Crc Schema (Optional)",
+                "default": 0,
+                "examples": [
+                  719
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/helpers.py
+++ b/helpers.py
@@ -13,7 +13,7 @@ from lxml import etree
 
 MOCK_DGCA_PRIVATE_KEY = os.path.join(os.path.dirname(os.path.realpath(__file__)), "Resources", "dgca_private.pem")
 MOCK_DGCA_CERTIFICATE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "Resources", "dgca.cert")
-
+LOG_SCHEMA = os.path.join(os.path.join(os.path.dirname(os.path.realpath(__file__)), "LogSchema.json"))
 
 
 def createArtifact(drone_uin, purpose, payloadWeight, payloadDetails,
@@ -190,3 +190,15 @@ def create_keys(folder, keyname):
     public_key = key.publickey().export_key()
     with open(os.path.join(folder, keyname + "_public.pem"), "wb") as file_out:
         file_out.write(public_key)
+
+
+def check_log_schema(logfile, schemafile=LOG_SCHEMA):
+    from jsonschema import validate, ValidationError
+    flightlog = json.loads(logfile)
+    with open(schemafile) as f:
+        logschema = json.loads(f.read())
+    try:
+        validate(instance=flightlog, schema=logschema)
+        return True
+    except ValidationError:
+        return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ lxml==4.2.1
 signxml==2.6.0
 cryptography==2.2.2
 pytz==2019.3
+jsonschema==3.1.1

--- a/tests/Flightlog-new-schema.json
+++ b/tests/Flightlog-new-schema.json
@@ -1,0 +1,41 @@
+{
+  "signature": "base64 encoded signature of the flightlog element",
+  "FlightLog": {
+    "PermissionArtefact": "ermission artefact ID of the current flightlog",
+    "previous_log_hash": "hash of the most recent flight log",
+    "LogEntries": [
+      {
+        "Entry_type": "TAKEOFF/ARM",
+        "TimeStamp": 41,
+        "Longitude": 380.000000,
+        "Latitude": 443.5000000,
+        "Altitude": 704.3400,
+        "CRC": 719
+      },
+      {
+        "Entry_type": "GEOFENCE_BREACH",
+        "TimeStamp": 505,
+        "Longitude": 11,
+        "Latitude": 701,
+        "Altitude": 7,
+        "CRC": 637
+      },
+      {
+        "Entry_type": "TIME_BREACH",
+        "TimeStamp": 81,
+        "Longitude": 116.5,
+        "Latitude": 996,
+        "Altitude": 560,
+        "CRC": 147
+      },
+      {
+        "Entry_type": "LAND/DISARM",
+        "TimeStamp": 81,
+        "Longitude": 116.5,
+        "Latitude": 996,
+        "Altitude": 560,
+        "CRC": 147
+      }
+    ]
+  }
+}

--- a/tests/test_flightlog.py
+++ b/tests/test_flightlog.py
@@ -42,6 +42,11 @@ class TestFlightLog(unittest.TestCase):
         etree.ElementTree(malart).write(self.bad_artefact_file)
         self.assertFalse(verify_xml_signature(self.bad_artefact_file, self.mock_dgca_cert))
 
+    def test_log_schema_verification(self):
+        with open("Flightlog-new-schema.json") as f:
+            log_file = f.read()
+        self.assertTrue(check_log_schema(logfile=log_file))
+
     # Sample method to generate a keypair
     # def test_keygen(self):
     #     create_keys(self.base_path, "sample_key")


### PR DESCRIPTION
Flight log schema has been added, this schema is supports all events
including takeoff, landing, and bundling. This commit adds a basic
schema validator using jsonchema and adds a unittest for the same.
Note that the schema validation is not included in the checks performed
by the apps in this commit.

A sample flightlog that conforms to the new schema is also provided.

Requirements.txt is updated to include jsonschema